### PR TITLE
Remove activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
 	"categories": [
 		"Visualization"
 	],
-	"activationEvents": [
-		"*"
-	],
+	"activationEvents": [],
 	"main": "dist/vscode_extension.js",
 	"contributes": {},
 	"scripts": {


### PR DESCRIPTION
The drawio extension for VS Code will activate this extension [when neccessary](https://github.com/hediet/vscode-drawio/blob/master/src/DrawioExtensionApi.ts#L28).

Thus, an unconstrained activation event is not required.